### PR TITLE
fix: add app-scoped release note image read endpoint (SAM-1178)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,12 @@
-* @amplify-sam
+* @aslakihle @equinor/amplify-frontend
+
+# Dependabot reviewers
+/action.yaml @aslakihle
+/action.yml @aslakihle
+/bun.lockb @aslakihle
+/bun.lock @aslakihle
+/package.json @aslakihle
+/.github/workflows/*.yaml @aslakihle
+/.github/workflows/*.yml @aslakihle
+/**/.github/workflows/*.yaml @aslakihle
+/**/.github/workflows/*.yml @aslakihle

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ package-lock.json
 # Webstorm user specific settings
 .idea/workspace.xml
 .idea/vcs.xml
+.idea
 
 # production
 /build

--- a/src/api/services/ReleaseNotesService.ts
+++ b/src/api/services/ReleaseNotesService.ts
@@ -20,7 +20,8 @@ export class ReleaseNotesService {
     });
   }
   /**
-   * Get release note image
+   @deprecated
+   Get release note image
    * @param path
    * @returns string OK
    * @throws ApiError
@@ -37,6 +38,31 @@ export class ReleaseNotesService {
       },
     });
   }
+
+  /**
+   * Get release note image
+   * @param applicationName
+   * @param path
+   * @returns string OK
+   * @throws ApiError
+   */
+  public static getReleaseNoteImageForApp(
+    applicationName: string,
+    path: string
+  ): CancelablePromise<string> {
+    return __request(OpenAPI_SAM, {
+      method: 'GET',
+      url: '/api/v1/ReleaseNotes/{applicationName}/releasenoteimages/{path}',
+      path: {
+        applicationName: applicationName,
+        path: path,
+      },
+      errors: {
+        404: `Not Found`,
+      },
+    });
+  }
+
   /**
    * Get published release notes
    * @param applicationName

--- a/src/api/services/ReleaseNotesService.ts
+++ b/src/api/services/ReleaseNotesService.ts
@@ -20,8 +20,8 @@ export class ReleaseNotesService {
     });
   }
   /**
-   @deprecated
-   Get release note image
+   * @deprecated
+   * Get release note image
    * @param path
    * @returns string OK
    * @throws ApiError


### PR DESCRIPTION
## Summary
Adds an app-scoped read endpoint for release note images so client apps can fetch images for their own application.

- Adds `ReleaseNotesService.getReleaseNoteImageForApp(applicationName, path)` using the app-scoped route `/api/v1/ReleaseNotes/{applicationName}/releasenoteimages/{path}`.
- Marks the non-app-scoped `getReleaseNoteImage` as deprecated.

This repo serves client apps, which only need to **read** release notes/images. Upload/manage endpoints remain the responsibility of the main SAM app.

## Ticket
[SAM-1178](https://upscaling.atlassian.net/browse/SAM-1178)

[SAM-1178]: https://upscaling.atlassian.net/browse/SAM-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ